### PR TITLE
Add .svelte extension to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.svelte linguist-language=HTML


### PR DESCRIPTION
For github syntax highlighting