### PR TITLE
Update README.md for Svelte v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can rename them with e.g. `bind:index={i}`.
 
 ## Configuring webpack
 
-If you're using webpack with [svelte-loader](https://github.com/sveltejs/svelte-loader), make sure that you add `"svelte"` to [`resolve.mainFields`](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in your webpack config. This ensures that webpack imports the uncompiled component (`src/index.html`) rather than the compiled version (`index.mjs`) — this is more efficient.
+If you're using webpack with [svelte-loader](https://github.com/sveltejs/svelte-loader), make sure that you add `"svelte"` to [`resolve.mainFields`](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in your webpack config. This ensures that webpack finds the uncompiled component (`Scroller.svelte`).
 
 If you're using Rollup with [rollup-plugin-svelte](https://github.com/rollup/rollup-plugin-svelte), this will happen automatically.
 


### PR DESCRIPTION
The uncompiled component is now named just `Scroller.svelte`.

Also, remove the misleading text about `index.mjs`: it's not just more efficient to use `Scroller.svelte`, but svelte-scroller no longer even builds or distributes an `index.js` or `index.mjs` file.