### PR TITLE
Only update index if a new section is 'selected'

### DIFF
--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -150,15 +150,18 @@
 			fixed = true;
 		}
 
-		for (index = 0; index < sections.length; index += 1) {
-			const section = sections[index];
+		for (let i = 0; i < sections.length; i++) {
+			const section = sections[i];
 			const { top } = section.getBoundingClientRect();
 
-			const next = sections[index + 1];
+			const next = sections[i + 1];
 			const bottom = next ? next.getBoundingClientRect().top : fg.bottom;
 
 			offset = (threshold_px - top) / (bottom - top);
-			if (bottom >= threshold_px) break;
+			if (bottom >= threshold_px) {
+				index = i;
+				break;
+			}
 		}
 	}
 </script>


### PR DESCRIPTION
Currently, `index` is updated on every scroll event, even if its value has not changed. This makes it tricky to add a function that is run only when a new section comes into view (which is probably what is required in #11, for example).

To see the current behavior, add the following line to the end of the script block in `App.svelte` in the [demo](https://svelte.dev/repl/76846b7ae27b3a21becb64ffd6e9d4a6?version=3.35.0).

```javascript
	$: console.log('Current section: ' + index);
```

As you scroll, 'Current section: 0' is logged many times.

The new version in this pull request only updates `index` (and calls any corresponding functions) if a new section is scrolled into position. This is done by using a new variable `i` rather than `index` as the index variable for the for-loop. Thus, `index` is only changed when the current section has changed.

