### PR TITLE
Fix width equalling 0 on load

### DIFF
--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -99,9 +99,10 @@
 		position: ${fixed ? 'fixed' : 'absolute'};
 		top: 0;
 		transform: translate(0, ${offset_top}px);
-		width: ${width}px;
 		z-index: ${inverted ? 3 : 1};
 	`;
+
+	$: widthStyle = fixed ? `width:${width}px;` : '';
 
 	onMount(() => {
 		sections = foreground.querySelectorAll(query);
@@ -166,7 +167,7 @@
 <svelte:window bind:innerHeight={wh}/>
 
 <svelte-scroller-outer bind:this={outer}>
-	<svelte-scroller-background-container class='background-container' {style}>
+	<svelte-scroller-background-container class='background-container' style="{style}{widthStyle}">
 		<svelte-scroller-background bind:this={background}>
 			<slot name="background"></slot>
 		</svelte-scroller-background>

--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -84,7 +84,7 @@
 	let sections;
 	let wh = 0;
 	let fixed;
-	let offset_top;
+	let offset_top = 0;
 	let width = 1;
 	let height;
 	let inverted;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-scroller/issues/13 by allowing width to be the natural CSS width when the scroller is absolutely positioned and setting it to the foreground width when it's in fixed position.