### PR TITLE
Added option to specify foreground z index

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following parameters are available:
 | threshold | 0.5       | Once a section crosses this point, it becomes 'active'                                                                                                                                                              |
 | query     | 'section' | A CSS selector that describes the individual sections of your foreground                                                                                                                                            |
 | parallax  | false     | If `true`, the background will scroll such that the bottom edge reaches the `bottom` at the same time as the foreground. This effect can be unpleasant for people with high motion sensitivity, so use it advisedly |
+| foregroundZIndex  | 2     | lets you specify the z-index of the foreground |
 
 ## `index`, `offset`, `progress` and `count`
 

--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -76,6 +76,7 @@
 	export let offset = 0;
 	export let progress = 0;
 	export let visible = false;
+  export let foregroundZIndex = 2;
 
 	let outer;
 	let foreground;
@@ -176,7 +177,7 @@
 		</svelte-scroller-background>
 	</svelte-scroller-background-container>
 
-	<svelte-scroller-foreground bind:this={foreground}>
+	<svelte-scroller-foreground style="z-index: {foregroundZIndex}" bind:this={foreground}>
 		<slot name="foreground"></slot>
 	</svelte-scroller-foreground>
 </svelte-scroller-outer>
@@ -196,7 +197,6 @@
 	svelte-scroller-foreground {
 		display: block;
 		position: relative;
-		z-index: 2;
 	}
 
 	svelte-scroller-foreground::after {


### PR DESCRIPTION
Hello,

By default, parent container of the foreground element has a z index of 2, which makes sense. But on mobile, it can be helpful for the background element to be on top of the foreground element.

This PR lets you specify the foreground z index as a property