### PR TITLE
Use position sticky

### DIFF
--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -83,7 +83,6 @@
 	let left;
 	let sections;
 	let wh = 0;
-	let fixed;
 	let offset_top = 0;
 	let width = 1;
 	let height;
@@ -96,13 +95,9 @@
 	$: (top, bottom, threshold, parallax, update());
 
 	$: style = `
-		position: ${fixed ? 'fixed' : 'absolute'};
-		top: 0;
 		transform: translate(0, ${offset_top}px);
 		z-index: ${inverted ? 3 : 1};
 	`;
-
-	$: widthStyle = fixed ? `width:${width}px;` : '';
 
 	onMount(() => {
 		sections = foreground.querySelectorAll(query);
@@ -138,17 +133,14 @@
 
 		if (progress <= 0) {
 			offset_top = 0;
-			fixed = false;
 		} else if (progress >= 1) {
 			offset_top = parallax
 				? (foreground_height - background_height)
 				: (foreground_height - available_space);
-			fixed = false;
 		} else {
 			offset_top = parallax ?
 				Math.round(top_px - progress * (background_height - available_space)) :
 				top_px;
-			fixed = true;
 		}
 
 		for (let i = 0; i < sections.length; i++) {
@@ -170,7 +162,7 @@
 <svelte:window bind:innerHeight={wh}/>
 
 <svelte-scroller-outer bind:this={outer}>
-	<svelte-scroller-background-container class='background-container' style="{style}{widthStyle}">
+	<svelte-scroller-background-container class='background-container' style="{style}">
 		<svelte-scroller-background bind:this={background}>
 			<slot name="background"></slot>
 		</svelte-scroller-background>
@@ -207,7 +199,8 @@
 
 	svelte-scroller-background-container {
 		display: block;
-		position: absolute;
+		position: sticky;
+		top: 0;
 		width: 100%;
 		max-width: 100%;
 		pointer-events: none;

--- a/Scroller.svelte
+++ b/Scroller.svelte
@@ -95,7 +95,7 @@
 	$: (top, bottom, threshold, parallax, update());
 
 	$: style = `
-		transform: translate(0, ${offset_top}px);
+		top: ${offset_top || top_px}px;
 		z-index: ${inverted ? 3 : 1};
 	`;
 
@@ -131,16 +131,8 @@
 		const available_space = bottom_px - top_px;
 		progress = (top_px - fg.top) / (foreground_height - available_space);
 
-		if (progress <= 0) {
-			offset_top = 0;
-		} else if (progress >= 1) {
-			offset_top = parallax
-				? (foreground_height - background_height)
-				: (foreground_height - available_space);
-		} else {
-			offset_top = parallax ?
-				Math.round(top_px - progress * (background_height - available_space)) :
-				top_px;
+		if (parallax) {
+			offset_top = Math.round(top_px - progress * (background_height - available_space));
 		}
 
 		for (let i = 0; i < sections.length; i++) {
@@ -162,8 +154,8 @@
 <svelte:window bind:innerHeight={wh}/>
 
 <svelte-scroller-outer bind:this={outer}>
-	<svelte-scroller-background-container class='background-container' style="{style}">
-		<svelte-scroller-background bind:this={background}>
+	<svelte-scroller-background-container class='background-container'>
+		<svelte-scroller-background bind:this={background} style="{style}">
 			<slot name="background"></slot>
 		</svelte-scroller-background>
 	</svelte-scroller-background-container>
@@ -181,7 +173,8 @@
 
 	svelte-scroller-background {
 		display: block;
-		position: relative;
+		position: sticky;
+		top: 0;
 		width: 100%;
 	}
 
@@ -199,9 +192,10 @@
 
 	svelte-scroller-background-container {
 		display: block;
-		position: sticky;
+		position: absolute;
 		top: 0;
 		width: 100%;
+		height: 100%;
 		max-width: 100%;
 		pointer-events: none;
 		/* height: 100%; */


### PR DESCRIPTION
Swaps the current fixed/absolute swap with position sticky. This is more efficient because we only update the offset once (except on parallax mode).

Moving the offset calculation outside of the intersection observer also has the benefit of positioning the background div on load rather than after the first scroll.

There's one breaking change though.  In the current code when you reach progress 1 the background div will go off the screen. In my experience this is confusing and position sticky approach where the background div stays fixed until you finish scrolling over the container is what most people actually want. Also, most scrollys i've seen tend to run a full height div on the background, where this point is moot. Thoughts welcome, of course!

Closes https://github.com/sveltejs/svelte-scroller/issues/16.

## before
### top 0 and bottom 1

https://github.com/sveltejs/svelte-scroller/assets/1236790/16363fab-caf3-47d0-b911-af65a5788359


### top 0.5 and bottom 1

https://github.com/sveltejs/svelte-scroller/assets/1236790/dcf030f3-da65-431d-99eb-d61fd75c7663

---

## after
### top 0 and bottom 1

https://github.com/sveltejs/svelte-scroller/assets/1236790/c06423f1-4778-4078-95fa-bf3dec13e343

### top 0.5 and bottom 1

https://github.com/sveltejs/svelte-scroller/assets/1236790/0aa32e24-556d-4318-81ff-3730e4fa8344

### top 0 and bottom 1 with full screen background

https://github.com/sveltejs/svelte-scroller/assets/1236790/e9148bb4-6615-46a0-8c69-cfc68318062b


